### PR TITLE
Фикс избранного в шаблоне Experience Simple v.1.0.0

### DIFF
--- a/common/templates/skin/experience-simple/tpls/comments/comment.single.tpl
+++ b/common/templates/skin/experience-simple/tpls/comments/comment.single.tpl
@@ -92,10 +92,11 @@
                         </li>
                         {if E::IsUser() AND !$bNoCommentFavourites}
                             <li class="comment-favourite bordered">
-                                <a class="link link-light-gray link-lead link-clear"
+                                <a class="link link-light-gray link-lead link-clear {if $oComment->getIsFavourite()}active{/if}"
                                    onclick="return ls.favourite.toggle({$oComment->getId()},this,'comment');"
                                    href="#">
-                                    <i class="fa fa-star-o"></i>
+                                    {if $oComment->getIsFavourite()}<i class="fa fa-star">{else}<i
+                                                class="fa fa-star-o">{/if}</i>
                                     <span class="small text-muted favourite-count"
                                           id="fav_count_comment_{$oComment->getId()}">{if $oComment->getCountFavourite() > 0}{$oComment->getCountFavourite()}{/if}</span>
                                 </a>


### PR DESCRIPTION
Если добавить комментарий в избранное из статьи, то со страницы избранного его не удалить, постоянно будет появляться сообщение «Этот комментарий уже есть в вашем избранном». Данный фикс решает проблему.